### PR TITLE
TensorFlow 1.4.0 support from train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 import numpy as np
 import re
 import os
+import sys
 import time
 import datetime
 import gc
@@ -39,7 +40,7 @@ tf.flags.DEFINE_boolean("allow_soft_placement", True, "Allow device soft device 
 tf.flags.DEFINE_boolean("log_device_placement", False, "Log placement of ops on devices")
 
 FLAGS = tf.flags.FLAGS
-FLAGS._parse_flags()
+FLAGS(sys.argv)
 print("\nParameters:")
 for attr, value in sorted(FLAGS.__flags.items()):
     print("{}={}".format(attr.upper(), value))


### PR DESCRIPTION
`FLAGS._parse_flags()` is no longer supported in TensorFlow 1.4.0. Use FLAGS(sys.argv) instead.